### PR TITLE
Centralize Stellar address, decimal, and UUID input validation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,14 +2,19 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  transform: {
+    "^.+\\.tsx?$": ["ts-jest", { tsconfig: "tsconfig.test.json" }],
+  },
   testMatch: [
     "<rootDir>/src/**/__tests__/**/*.test.ts",
     "<rootDir>/src/apiKeyAuth.test.ts",
     "<rootDir>/src/indexerWebhook.test.ts",
+    "<rootDir>/src/validation/**/*.test.ts",
   ],
   collectCoverageFrom: [
     "src/cache/**/*.ts",
     "src/services/**/*.ts",
+    "src/validation/**/*.ts",
   ],
   coverageThreshold: {
     global: {

--- a/src/api/v1/streams.ts
+++ b/src/api/v1/streams.ts
@@ -9,12 +9,11 @@ import { accrualService } from "../../services/accrualService";
 import {
   getStreamsQuerySchema,
   uuidParamSchema,
+  uuidSchema,
 } from "../../validation/schemas";
 
 const router = Router();
 const streamRepository = new StreamRepository();
-
-const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const allowedUpdateFields = new Set(["labels", "offChainMemo", "status", "updatedAt"]);
 const validStreamStatuses = ["active", "paused", "cancelled", "completed"] as const;
 
@@ -31,7 +30,7 @@ router.get("/:id/accrual-preview", async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
 
-    if (!uuidRegex.test(id)) {
+    if (!uuidSchema.safeParse(id).success) {
       return res.status(400).json({ error: "Invalid stream ID format" });
     }
 
@@ -82,7 +81,7 @@ router.patch("/:id", async (req: Request, res: Response) => {
     const { id } = req.params;
     const requestBody = req.body ?? {};
 
-    if (!uuidRegex.test(id)) {
+    if (!uuidSchema.safeParse(id).success) {
       return res.status(400).json({ error: "Invalid stream ID format" });
     }
 

--- a/src/api/v1/webhooks.ts
+++ b/src/api/v1/webhooks.ts
@@ -9,6 +9,7 @@
 import { Router, Request, Response } from "express";
 import crypto from "crypto";
 import { z } from "zod";
+import { uuidSchema } from "../../validation/schemas";
 import { webhookRepository } from "../../repositories/webhookRepository";
 
 const router = Router();
@@ -66,8 +67,7 @@ router.get("/", async (_req: Request, res: Response) => {
 // DELETE /api/v1/webhooks/:id
 router.delete("/:id", async (req: Request, res: Response) => {
   const { id } = req.params;
-  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-  if (!uuidRegex.test(id)) {
+  if (!uuidSchema.safeParse(id).success) {
     return res.status(400).json({ error: "Invalid subscription ID format" });
   }
 

--- a/src/validation/schemas.test.ts
+++ b/src/validation/schemas.test.ts
@@ -1,0 +1,101 @@
+import {
+  stellarAddressSchema,
+  decimalAmountSchema,
+  uuidSchema,
+  getStreamsQuerySchema,
+  uuidParamSchema,
+} from "./schemas";
+
+describe("stellarAddressSchema", () => {
+  const valid = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+  it.each([
+    ["valid Stellar address", valid, true],
+    ["too short", "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567", false],
+    ["too long", valid + "A", false],
+    ["does not start with G", "LABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ23", false],
+    ["contains lowercase", "gABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ23", false],
+    ["contains invalid char 0", "G0BCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ23", false],
+    ["contains invalid char 1", "G1BCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ23", false],
+    ["contains invalid char 8", "G8BCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ23", false],
+    ["contains invalid char 9", "G9BCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ23", false],
+    ["empty string", "", false],
+  ])("%s", (_label, input, expectedValid) => {
+    const result = stellarAddressSchema.safeParse(input);
+    expect(result.success).toBe(expectedValid);
+  });
+});
+
+describe("decimalAmountSchema", () => {
+  it.each([
+    ["integer", "100", true],
+    ["decimal with 1 fractional digit", "0.1", true],
+    ["decimal with 9 fractional digits", "123.123456789", true],
+    ["large number", "99999999999999999999", true],
+    ["small positive", "0.000000001", true],
+    ["zero", "0", false],
+    ["negative", "-5", false],
+    ["too many fractional digits (10)", "1.1234567890", false],
+    ["not a number", "abc", false],
+    ["empty string", "", false],
+    ["empty after decimal", "1.", false],
+    ["leading zero", "0.5", true],
+  ])("%s", (_label, input, expectedValid) => {
+    const result = decimalAmountSchema.safeParse(input);
+    expect(result.success).toBe(expectedValid);
+  });
+});
+
+describe("uuidSchema", () => {
+  it.each([
+    ["valid UUID v4", "550e8400-e29b-411d-a716-446655440000", true],
+    ["valid UUID with uppercase", "550E8400-E29B-411D-A716-446655440000", true],
+    ["invalid: not a UUID", "not-a-uuid", false],
+    ["invalid: wrong format", "123e4567-e89b-12d3-a456", false],
+    ["empty string", "", false],
+  ])("%s", (_label, input, expectedValid) => {
+    const result = uuidSchema.safeParse(input);
+    expect(result.success).toBe(expectedValid);
+  });
+});
+
+describe("getStreamsQuerySchema", () => {
+  it("accepts empty query", () => {
+    const result = getStreamsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid filter fields", () => {
+    const result = getStreamsQuerySchema.safeParse({
+      payer: "GPAYER",
+      recipient: "GRECIPIENT",
+      status: "active",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid status", () => {
+    const result = getStreamsQuerySchema.safeParse({ status: "invalid" });
+    expect(result.success).toBe(false);
+  });
+
+  it("coerces numeric limit", () => {
+    const result = getStreamsQuerySchema.safeParse({ limit: "10" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(10);
+    }
+  });
+});
+
+describe("uuidParamSchema", () => {
+  it("accepts a valid UUID", () => {
+    const result = uuidParamSchema.safeParse({ id: "550e8400-e29b-411d-a716-446655440000" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid UUID", () => {
+    const result = uuidParamSchema.safeParse({ id: "bad-id" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -1,5 +1,47 @@
 import { z } from "zod";
 
+// ---------------------------------------------------------------------------
+// Shared primitive validators
+// ---------------------------------------------------------------------------
+
+/**
+ * Stellar ed25519 public key (G... account address).
+ *
+ * - Exactly 56 characters long
+ * - Starts with 'G'
+ * - Valid base32 character set (A–Z, 2–7)
+ */
+export const stellarAddressSchema = z
+  .string()
+  .length(56, "Stellar address must be exactly 56 characters")
+  .regex(
+    /^G[A-Z2-7]{55}$/,
+    "Stellar address must start with 'G' and contain only valid base32 characters",
+  );
+
+/**
+ * Positive decimal string matching a `decimal(20,9)` database column.
+ *
+ * - Must be parseable as a positive number
+ * - At most 9 digits after the decimal point
+ */
+export const decimalAmountSchema = z
+  .string()
+  .regex(
+    /^\d+(\.\d{1,9})?$/,
+    "Must be a positive decimal string with at most 9 fractional digits",
+  )
+  .refine((val) => parseFloat(val) > 0, "Must be greater than 0");
+
+/**
+ * Reusable canonical UUID schema.
+ */
+export const uuidSchema = z.string().uuid();
+
+// ---------------------------------------------------------------------------
+// Request-level schemas
+// ---------------------------------------------------------------------------
+
 /**
  * Streams query validation
  */
@@ -15,5 +57,5 @@ export const getStreamsQuerySchema = z.object({
  * UUID param validation
  */
 export const uuidParamSchema = z.object({
-  id: z.string().uuid(),
+  id: uuidSchema,
 });

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.ts"]
+}


### PR DESCRIPTION
Closes #191

## Summary

Centralizes Stellar address, decimal amount, and UUID validation into shared Zod schemas in `src/validation/schemas.ts`.

## Changes

- **src/validation/schemas.ts**: Added `stellarAddressSchema` (56-char G-prefixed base32), `decimalAmountSchema` (positive decimal with ≤9 fractional digits), and `uuidSchema` (canonical UUID). Updated `uuidParamSchema` to use the shared `uuidSchema`.
- **src/api/v1/streams.ts**: Removed inline `uuidRegex` in favor of `uuidSchema.safeParse()`.
- **src/api/v1/webhooks.ts**: Removed inline `uuidRegex` in favor of `uuidSchema.safeParse()`.
- **src/validation/schemas.test.ts**: 33 table-driven tests covering all validators.
- **jest.config.js / tsconfig.test.json**: Added test infrastructure for validation tests.