### PR TITLE
feat(security): persist indexer webhook idempotency

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -18,8 +18,10 @@ Key security controls include:
   before JSON/raw-body parsing for protected routes.
 - **HMAC verification** of indexer webhook payloads against the raw request
   body, using `INDEXER_WEBHOOK_SECRET`.
-- **Replay protection** via deduplication of `eventId` values in the
-  ingestion service.
+- **Durable replay protection** via a Postgres-backed
+  `processed_indexer_events` ledger keyed by indexer `eventId`. Signature and
+  payload validation run before an event id is recorded, and duplicate ids are
+  rejected atomically by the database unique constraint.
 - **IP-based and API-key-based rate limiting** through `express-rate-limit`.
 - **Strict CORS** allowlists in production (no wildcard).
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -37,6 +37,17 @@ The core table for managing payment streams aligned with the Soroban contract mo
 | `cancelled` | Stream was cancelled before completion |
 | `completed` | Stream finished its full duration |
 
+### `processed_indexer_events`
+
+Stores indexer webhook event ids after HMAC signature and payload validation.
+The primary key makes replay detection durable across deploys and service
+replicas.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `event_id` | `varchar(255)` | PRIMARY KEY | Unique indexer event identifier |
+| `received_at` | `timestamp` | NOT NULL, DEFAULT `now()` | First accepted delivery timestamp |
+
 ## Indexes
 
 The following indexes are created for efficient querying:
@@ -48,6 +59,7 @@ The following indexes are created for efficient querying:
 | `streams_status_idx` | `status` | Filter streams by status |
 | `streams_chain_id_idx` | `chain_id` | Filter streams by blockchain network |
 | `streams_created_at_idx` | `created_at` | Sort/filter by creation time |
+| `processed_indexer_events_pkey` | `event_id` | Atomic replay detection for indexer webhooks |
 
 ## Invariants
 

--- a/drizzle/0002_create_processed_indexer_events.sql
+++ b/drizzle/0002_create_processed_indexer_events.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS "processed_indexer_events" (
+  "event_id" varchar(255) PRIMARY KEY NOT NULL,
+  "received_at" timestamp DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781678686511,
       "tag": "0001_add_streams_deleted_at",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781680800000,
+      "tag": "0002_create_processed_indexer_events",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -114,3 +114,11 @@ export type WebhookSubscription = typeof webhookSubscriptions.$inferSelect;
 export type NewWebhookSubscription = typeof webhookSubscriptions.$inferInsert;
 export type WebhookDelivery = typeof webhookDeliveries.$inferSelect;
 export type NewWebhookDelivery = typeof webhookDeliveries.$inferInsert;
+
+export const processedIndexerEvents = pgTable("processed_indexer_events", {
+  eventId: varchar("event_id", { length: 255 }).primaryKey(),
+  receivedAt: timestamp("received_at").defaultNow().notNull(),
+});
+
+export type ProcessedIndexerEvent = typeof processedIndexerEvents.$inferSelect;
+export type NewProcessedIndexerEvent = typeof processedIndexerEvents.$inferInsert;

--- a/src/indexerWebhook.test.ts
+++ b/src/indexerWebhook.test.ts
@@ -25,16 +25,16 @@ function sign(body: string): string {
 }
 
 describe("POST /webhooks/indexer", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     process.env.INDEXER_WEBHOOK_SECRET = secret;
     process.env.API_KEYS = "test-1234";
     refreshApiKeyStore();
-    eventIngestionService.reset();
+    await eventIngestionService.reset();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     jest.restoreAllMocks();
-    eventIngestionService.reset();
+    await eventIngestionService.reset();
     apiKeyStore.clear();
     delete process.env.INDEXER_WEBHOOK_SECRET;
     delete process.env.API_KEYS;
@@ -263,16 +263,16 @@ describe("POST /webhooks/indexer - settlement idempotency", () => {
     },
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     process.env.INDEXER_WEBHOOK_SECRET = secret;
     process.env.API_KEYS = "test-1234";
     refreshApiKeyStore();
-    eventIngestionService.reset();
+    await eventIngestionService.reset();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     jest.restoreAllMocks();
-    eventIngestionService.reset();
+    await eventIngestionService.reset();
     apiKeyStore.clear();
     delete process.env.INDEXER_WEBHOOK_SECRET;
     delete process.env.API_KEYS;
@@ -364,6 +364,7 @@ describe("POST /webhooks/indexer - settlement idempotency", () => {
 
     // In a real implementation, settlementProcessor would be called exactly once
     // For this test, we verify the ingestion service correctly identifies duplicates
+    expect(settlementProcessor).not.toHaveBeenCalled();
     expect(responses[0].body.duplicate).toBe(false);
     expect(responses[1].body.duplicate).toBe(true);
     expect(responses[2].body.duplicate).toBe(true);
@@ -454,7 +455,7 @@ describe("POST /webhooks/indexer - settlement idempotency", () => {
     expect(firstResponse.body.duplicate).toBe(false);
 
     // Reset the service (simulating service restart)
-    eventIngestionService.reset();
+    await eventIngestionService.reset();
 
     // Second delivery after reset should be treated as new
     const secondResponse = await request(app)

--- a/src/repositories/processedIndexerEventRepository.ts
+++ b/src/repositories/processedIndexerEventRepository.ts
@@ -1,0 +1,48 @@
+import { db } from "../db/index";
+import { processedIndexerEvents } from "../db/schema";
+
+export interface ProcessedIndexerEventStore {
+  record(eventId: string): Promise<boolean>;
+  reset(): Promise<void>;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && (error as { code?: unknown }).code === "23505";
+}
+
+export class ProcessedIndexerEventRepository implements ProcessedIndexerEventStore {
+  async record(eventId: string): Promise<boolean> {
+    try {
+      await db.insert(processedIndexerEvents).values({ eventId });
+      return true;
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async reset(): Promise<void> {
+    await db.delete(processedIndexerEvents);
+  }
+}
+
+export class InMemoryProcessedIndexerEventStore implements ProcessedIndexerEventStore {
+  private readonly eventIds = new Set<string>();
+
+  async record(eventId: string): Promise<boolean> {
+    if (this.eventIds.has(eventId)) {
+      return false;
+    }
+    this.eventIds.add(eventId);
+    return true;
+  }
+
+  async reset(): Promise<void> {
+    this.eventIds.clear();
+  }
+}

--- a/src/routes/webhooks/indexer.ts
+++ b/src/routes/webhooks/indexer.ts
@@ -12,7 +12,7 @@ router.post(
   "/",
   apiKeyAuthMiddleware,
   rawJsonBodyParser,
-  (req: Request<Record<string, never>, unknown, Buffer>, res: Response) => {
+  async (req: Request<Record<string, never>, unknown, Buffer>, res: Response) => {
     if (!Buffer.isBuffer(req.body)) {
       return res.status(400).json({
         error: "invalid_body",
@@ -21,7 +21,7 @@ router.post(
     }
 
     const signatureHeader = req.header("x-indexer-signature") ?? undefined;
-    const result = eventIngestionService.ingest(req.body, signatureHeader);
+    const result = await eventIngestionService.ingest(req.body, signatureHeader);
 
     if (!result.accepted) {
       const statusByCode = {
@@ -29,6 +29,7 @@ router.post(
         invalid_signature: 401,
         invalid_json: 400,
         invalid_payload: 400,
+        idempotency_unavailable: 503,
       } as const;
 
       return res.status(statusByCode[result.code]).json({

--- a/src/services/__tests__/eventIngestionService.test.ts
+++ b/src/services/__tests__/eventIngestionService.test.ts
@@ -1,0 +1,93 @@
+import crypto from "crypto";
+
+import { EventIngestionService } from "../eventIngestionService";
+import type { ProcessedIndexerEventStore } from "../../repositories/processedIndexerEventRepository";
+
+const secret = "test-indexer-secret";
+
+const payload = {
+  eventId: "evt_persistent_123",
+  eventType: "settled",
+  streamId: "stream_456",
+  occurredAt: "2026-03-23T10:00:00.000Z",
+};
+
+class FakeProcessedIndexerEventStore implements ProcessedIndexerEventStore {
+  readonly eventIds = new Set<string>();
+  readonly calls: string[] = [];
+  failRecord = false;
+
+  async record(eventId: string): Promise<boolean> {
+    this.calls.push(eventId);
+    if (this.failRecord) {
+      throw new Error("database unavailable");
+    }
+    if (this.eventIds.has(eventId)) {
+      return false;
+    }
+    this.eventIds.add(eventId);
+    return true;
+  }
+
+  async reset(): Promise<void> {
+    this.eventIds.clear();
+    this.calls.length = 0;
+  }
+}
+
+function sign(body: string): string {
+  const digest = crypto.createHmac("sha256", secret).update(body).digest("hex");
+  return `sha256=${digest}`;
+}
+
+describe("EventIngestionService", () => {
+  beforeEach(() => {
+    process.env.INDEXER_WEBHOOK_SECRET = secret;
+  });
+
+  afterEach(() => {
+    delete process.env.INDEXER_WEBHOOK_SECRET;
+  });
+
+  it("uses the injected event store so duplicates survive fresh service instances", async () => {
+    const store = new FakeProcessedIndexerEventStore();
+    const body = Buffer.from(JSON.stringify(payload));
+    const signature = sign(body.toString("utf8"));
+
+    const firstService = new EventIngestionService(store);
+    const first = await firstService.ingest(body, signature);
+
+    const restartedService = new EventIngestionService(store);
+    const replay = await restartedService.ingest(body, signature);
+
+    expect(first).toMatchObject({ accepted: true, duplicate: false });
+    expect(replay).toMatchObject({ accepted: true, duplicate: true });
+    expect(store.calls).toEqual([payload.eventId, payload.eventId]);
+  });
+
+  it("validates signatures and payloads before recording idempotency", async () => {
+    const store = new FakeProcessedIndexerEventStore();
+    const service = new EventIngestionService(store);
+    const body = Buffer.from(JSON.stringify(payload));
+
+    const result = await service.ingest(body, "sha256=deadbeef");
+
+    expect(result).toMatchObject({ accepted: false, code: "invalid_signature" });
+    expect(store.calls).toEqual([]);
+  });
+
+  it("fails closed when the persistent replay store is unavailable", async () => {
+    const store = new FakeProcessedIndexerEventStore();
+    store.failRecord = true;
+
+    const service = new EventIngestionService(store);
+    const body = Buffer.from(JSON.stringify(payload));
+    const result = await service.ingest(body, sign(body.toString("utf8")));
+
+    expect(result).toEqual({
+      accepted: false,
+      code: "idempotency_unavailable",
+      message: "Webhook replay protection is unavailable.",
+    });
+  });
+});

--- a/src/services/eventIngestionService.ts
+++ b/src/services/eventIngestionService.ts
@@ -1,4 +1,9 @@
 import crypto from "crypto";
+import {
+  InMemoryProcessedIndexerEventStore,
+  ProcessedIndexerEventRepository,
+  type ProcessedIndexerEventStore,
+} from "../repositories/processedIndexerEventRepository";
 
 export type IndexerEventPayload = {
   eventId: string;
@@ -20,7 +25,8 @@ export type IngestionFailureCode =
   | "missing_secret"
   | "invalid_signature"
   | "invalid_json"
-  | "invalid_payload";
+  | "invalid_payload"
+  | "idempotency_unavailable";
 
 export type IngestionFailureResult = {
   accepted: false;
@@ -33,9 +39,9 @@ export type IngestionResult = IngestionSuccessResult | IngestionFailureResult;
 const SIGNATURE_PREFIX = "sha256=";
 
 export class EventIngestionService {
-  private readonly processedEventIds = new Set<string>();
+  constructor(private readonly processedEvents: ProcessedIndexerEventStore) {}
 
-  ingest(rawBody: Buffer, signatureHeader: string | undefined): IngestionResult {
+  async ingest(rawBody: Buffer, signatureHeader: string | undefined): Promise<IngestionResult> {
     const secret = process.env.INDEXER_WEBHOOK_SECRET;
 
     if (!secret) {
@@ -75,25 +81,26 @@ export class EventIngestionService {
       };
     }
 
-    if (this.processedEventIds.has(event.eventId)) {
+    let firstDelivery: boolean;
+    try {
+      firstDelivery = await this.processedEvents.record(event.eventId);
+    } catch {
       return {
-        accepted: true,
-        duplicate: true,
-        event,
+        accepted: false,
+        code: "idempotency_unavailable",
+        message: "Webhook replay protection is unavailable.",
       };
     }
 
-    this.processedEventIds.add(event.eventId);
-
     return {
       accepted: true,
-      duplicate: false,
+      duplicate: !firstDelivery,
       event,
     };
   }
 
-  reset(): void {
-    this.processedEventIds.clear();
+  async reset(): Promise<void> {
+    await this.processedEvents.reset();
   }
 
   private isValidSignature(rawBody: Buffer, signatureHeader: string, secret: string): boolean {
@@ -137,4 +144,11 @@ export class EventIngestionService {
   }
 }
 
-export const eventIngestionService = new EventIngestionService();
+function createDefaultReplayStore(): ProcessedIndexerEventStore {
+  if (process.env.NODE_ENV === "test") {
+    return new InMemoryProcessedIndexerEventStore();
+  }
+  return new ProcessedIndexerEventRepository();
+}
+
+export const eventIngestionService = new EventIngestionService(createDefaultReplayStore());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "declaration": true,
-    "declarationMap": true,
+    "declaration": false,
+    "declarationMap": false,
     "sourceMap": true,
     "types": ["jest", "node"]
   },


### PR DESCRIPTION
## Summary

- adds a `processed_indexer_events` Drizzle table and migration keyed by `event_id`
- replaces in-process indexer replay dedupe with an injected store backed by the new table in non-test environments
- keeps signature and payload validation before idempotency recording, and fails closed with `503` if replay protection is unavailable
- documents durable replay protection in `docs/SECURITY.md` and `docs/data-model.md`
- disables declaration output for the backend app build so `npm run build`/`tsc` no longer fails on TS2883 portable declaration paths from Express/Drizzle inferred exports

Closes #187

## Validation

- `pnpm run build`
- `pnpm exec jest --runInBand`
- `pnpm exec eslint src/services/eventIngestionService.ts src/services/__tests__/eventIngestionService.test.ts src/repositories/processedIndexerEventRepository.ts src/routes/webhooks/indexer.ts src/indexerWebhook.test.ts --max-warnings 0`
- `git diff --check`
